### PR TITLE
[PROD] hotfix/card-901270943 - Subir em 02/04/2024

### DIFF
--- a/storage/wsnfe_3.10_mod65.xml
+++ b/storage/wsnfe_3.10_mod65.xml
@@ -108,7 +108,7 @@
     </producao>
   </UF>
   <UF>
-    <!-- NOTA: ES usa o SVRS -->  
+    <!-- NOTA: ES usa o SVRS -->
     <sigla>ES</sigla>
     <homologacao>
       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://homologacao.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx</NfeConsultaQR>
@@ -116,7 +116,7 @@
     <producao>
       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://app.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx</NfeConsultaQR>
     </producao>
-  </UF>  
+  </UF>
   <UF>
     <sigla>GO</sigla>
     <homologacao>
@@ -189,10 +189,10 @@
   <UF>
     <sigla>PB</sigla>
     <homologacao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.receita.pb.gov.br/nfcehom</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.sefaz.pb.gov.br/nfcehom</NfeConsultaQR>
     </homologacao>
     <producao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.receita.pb.gov.br/nfce</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.sefaz.pb.gov.br/nfce</NfeConsultaQR>
     </producao>
   </UF>
   <UF>

--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -205,10 +205,10 @@
   <UF>
     <sigla>PB</sigla>
     <homologacao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.receita.pb.gov.br/nfcehom</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.sefaz.pb.gov.br/nfcehom</NfeConsultaQR>
     </homologacao>
     <producao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.receita.pb.gov.br/nfce</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.sefaz.pb.gov.br/nfce</NfeConsultaQR>
     </producao>
   </UF>
   <UF>

--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -139,7 +139,7 @@
             <NfeConsultaProtocolo method="nfeConsultaNF" operation="NFeConsulta4" version="4.00">https://hnfce.fazenda.mg.gov.br/nfce/services/NFeConsultaProtocolo4</NfeConsultaProtocolo>
             <NfeStatusServico method="nfeStatusServicoNF" operation="NFeStatusServico4" version="4.00">https://hnfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4</NfeStatusServico>
             <RecepcaoEvento method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento4" version="1.00">https://hnfce.fazenda.mg.gov.br/nfce/services/NFeRecepcaoEvento4</RecepcaoEvento>
-            <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://nfce.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml</NfeConsultaQR>
+            <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml</NfeConsultaQR>
         </homologacao>
         <producao>
             <NfeAutorizacao method="nfeAutorizacaoLote" operation="NFeAutorizacao4" version="4.00">https://nfce.fazenda.mg.gov.br/nfce/services/NFeAutorizacao4</NfeAutorizacao>
@@ -148,7 +148,7 @@
             <NfeConsultaProtocolo method="nfeConsultaNF" operation="NFeConsulta4" version="4.00">https://nfce.fazenda.mg.gov.br/nfce/services/NFeConsultaProtocolo4</NfeConsultaProtocolo>
             <NfeStatusServico method="nfeStatusServicoNF" operation="NFeStatusServico4" version="4.00">https://nfce.fazenda.mg.gov.br/nfce/services/NFeStatusServico4</NfeStatusServico>
             <RecepcaoEvento method="nfeRecepcaoEvento" operation="NFeRecepcaoEvento4" version="1.00">https://nfce.fazenda.mg.gov.br/nfce/services/NFeRecepcaoEvento4</RecepcaoEvento>
-            <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://nfce.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml</NfeConsultaQR>
+            <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml</NfeConsultaQR>
         </producao>
     </UF>
   <UF>


### PR DESCRIPTION
Alteração da URL de inclusão do QR Code de consulta estadual da NFC-e no estado da PB.

[Comunicado](https://www.sefaz.pb.gov.br/announcements/14612-sefaz-pb-comunica-endereco-unico-para-inclusao-de-codigo-do-qr-code-da-nota-fiscal-eletronica-ao-consumidor-nfc-e-2)