### PR TITLE
hotfix/card-901270943-2

### DIFF
--- a/storage/wsnfe_3.10_mod65.xml
+++ b/storage/wsnfe_3.10_mod65.xml
@@ -108,7 +108,7 @@
     </producao>
   </UF>
   <UF>
-    <!-- NOTA: ES usa o SVRS -->  
+    <!-- NOTA: ES usa o SVRS -->
     <sigla>ES</sigla>
     <homologacao>
       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://homologacao.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx</NfeConsultaQR>
@@ -116,7 +116,7 @@
     <producao>
       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://app.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx</NfeConsultaQR>
     </producao>
-  </UF>  
+  </UF>
   <UF>
     <sigla>GO</sigla>
     <homologacao>
@@ -189,10 +189,10 @@
   <UF>
     <sigla>PB</sigla>
     <homologacao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.receita.pb.gov.br/nfcehom</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.sefaz.pb.gov.br/nfcehom</NfeConsultaQR>
     </homologacao>
     <producao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.receita.pb.gov.br/nfce</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100">http://www.sefaz.pb.gov.br/nfce</NfeConsultaQR>
     </producao>
   </UF>
   <UF>

--- a/storage/wsnfe_4.00_mod65.xml
+++ b/storage/wsnfe_4.00_mod65.xml
@@ -205,10 +205,10 @@
   <UF>
     <sigla>PB</sigla>
     <homologacao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.receita.pb.gov.br/nfcehom</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.sefaz.pb.gov.br/nfcehom</NfeConsultaQR>
     </homologacao>
     <producao>
-      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.receita.pb.gov.br/nfce</NfeConsultaQR>
+      <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="200">http://www.sefaz.pb.gov.br/nfce</NfeConsultaQR>
     </producao>
   </UF>
   <UF>


### PR DESCRIPTION
Alteração da URL de inclusão do QR Code de consulta estadual da NFC-e.

[Comunicado](https://www.sefaz.pb.gov.br/announcements/14612-sefaz-pb-comunica-endereco-unico-para-inclusao-de-codigo-do-qr-code-da-nota-fiscal-eletronica-ao-consumidor-nfc-e-2)